### PR TITLE
Accurately represent protocol in `Answer` enum

### DIFF
--- a/src/answer.rs
+++ b/src/answer.rs
@@ -38,10 +38,14 @@ pub struct Error {
 
 #[derive(Serialize, Debug, Eq, PartialEq)]
 #[serde(untagged)]
-pub enum Answer {
+pub enum Action {
     Install(Install),
     Remove(Remove),
     Autoremove(Autoremove),
+}
+
+pub enum Answer {
+    Solution(Vec<Action>),
     Error(Error),
 }
 
@@ -56,7 +60,7 @@ mod tests {
         let repr = indoc! {"
             Install: abc
         "};
-        let val = Answer::Install(Install {
+        let val = Action::Install(Install {
             install: "abc".into(),
             ..Default::default()
         });

--- a/src/answer.rs
+++ b/src/answer.rs
@@ -2,10 +2,15 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use super::scenario::Version;
+
 #[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Install {
     pub install: String,
+    pub package: Option<String>,
+    pub version: Option<Version>,
+    pub architecture: Option<String>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, String>,
@@ -15,6 +20,9 @@ pub struct Install {
 #[serde(rename_all = "PascalCase")]
 pub struct Remove {
     pub remove: String,
+    pub package: Option<String>,
+    pub version: Option<Version>,
+    pub architecture: Option<String>,
 
     #[serde(flatten)]
     pub extra: HashMap<String, String>,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct Progress {
-    progress: String,
-    percentage: Option<String>,
-    message: Option<String>,
+    pub progress: String,
+    pub percentage: Option<String>,
+    pub message: Option<String>,
 }


### PR DESCRIPTION
Make the `Answer` enum contain a `Solution` and an `Error`, as the [EDSP describes](https://salsa.debian.org/apt-team/apt/-/blob/a8367745eac915281cc2b9fb98813e9225d1e55c/doc/external-dependency-solver-protocol.md#answer).